### PR TITLE
Fix mount jdk8

### DIFF
--- a/docker-job.sh
+++ b/docker-job.sh
@@ -24,13 +24,13 @@ else
 
   readonly DOCKER_IMAGE=${DOCKER_IMAGE:-'rhel6-jenkins-shared-slave'}
 
-  readonly JAVAZI_MOUNT=${JAVAZI_MOUNT:-'/usr/share/javazi-1.8/:/usr/share/javazi-1.8/'}
-  readonly WORKSPACE_MOUNT="${WORKSPACE}:/workspace"
-  readonly MAVEN_HOME_MOUNT="${MAVEN_HOME}:/maven_home"
-  readonly JAVA_HOME_MOUNT="${JAVA_HOME}:/java"
-  readonly OPT_MOUNT='/opt:/opt'
+  readonly DOCKER_JAVAZI_MOUNT=${DOCKER_JAVAZI_MOUNT:-'/usr/share/javazi-1.8/:/usr/share/javazi-1.8/'}
+  readonly DOCKER_WORKSPACE_MOUNT="${WORKSPACE}:/workspace"
+  readonly DOCKER_MAVEN_HOME_MOUNT="${MAVEN_HOME}:/maven_home"
+  readonly DOCKER_JAVA_HOME_MOUNT="${JAVA_HOME}:/java"
+  readonly DOCKER_OPT_MOUNT='/opt:/opt'
 
-  readonly CONTAINER_ID=$(docker run -d -v "${WORKSPACE_MOUNT}"  -v "${MAVEN_HOME_MOUNT}" -v "${JAVAZI_MOUNT}" -v "${JAVA_HOME_MOUNT}" -v "${OPT_MOUNT}" -v $(pwd):/job_home "${DOCKER_IMAGE}")
+  readonly CONTAINER_ID=$(docker run -d -v "${DOCKER_WORKSPACE_MOUNT}" -v "${DOCKER_MAVEN_HOME_MOUNT}" -v "${DOCKER_JAVAZI_MOUNT}" -v "${DOCKER_JAVA_HOME_MOUNT}" -v "${DOCKER_OPT_MOUNT}" -v $(pwd):/job_home "${DOCKER_IMAGE}")
 
   if [ "${?}" -ne 0 ]; then
     echo 'Failed to create container.'

--- a/docker-job.sh
+++ b/docker-job.sh
@@ -25,8 +25,12 @@ else
   readonly DOCKER_IMAGE=${DOCKER_IMAGE:-'rhel6-jenkins-shared-slave'}
 
   readonly JAVAZI_MOUNT=${JAVAZI_MOUNT:-'/usr/share/javazi-1.8/:/usr/share/javazi-1.8/'}
+  readonly WORKSPACE_MOUNT="${WORKSPACE}:/workspace"
+  readonly MAVEN_HOME_MOUNT="${MAVEN_HOME}:/maven_home"
+  readonly JAVA_HOME_MOUNT="${JAVA_HOME}:/java"
+  readonly OPT_MOUNT='/opt:/opt'
 
-  readonly CONTAINER_ID=$(docker run -d -v "${WORKSPACE}:/workspace"  -v "${MAVEN_HOME}:/maven_home" -v ${JAVAZI_MOUNT} -v "${JAVA_HOME}:/java" -v "${OLD_RELEASES_FOLDER}:${OLD_RELEASES_FOLDER}" -v $(pwd):/job_home "${DOCKER_IMAGE}")
+  readonly CONTAINER_ID=$(docker run -d -v "${WORKSPACE_MOUNT}"  -v "${MAVEN_HOME_MOUNT}" -v "${JAVAZI_MOUNT}" -v "${JAVA_HOME_MOUNT}" -v "${OPT_MOUNT}" -v $(pwd):/job_home "${DOCKER_IMAGE}")
 
   if [ "${?}" -ne 0 ]; then
     echo 'Failed to create container.'

--- a/docker-job.sh
+++ b/docker-job.sh
@@ -24,7 +24,9 @@ else
 
   readonly DOCKER_IMAGE=${DOCKER_IMAGE:-'rhel6-jenkins-shared-slave'}
 
-  readonly CONTAINER_ID=$(docker run -d -v "${WORKSPACE}:/workspace"  -v "${MAVEN_HOME}:/maven_home" -v "${JAVA_HOME}:/java" -v "${OLD_RELEASES_FOLDER}:${OLD_RELEASES_FOLDER}" -v $(pwd):/job_home "${DOCKER_IMAGE}")
+  readonly JAVAZI_MOUNT=${JAVAZI_MOUNT:-'/usr/share/javazi-1.8/:/usr/share/javazi-1.8/'}
+
+  readonly CONTAINER_ID=$(docker run -d -v "${WORKSPACE}:/workspace"  -v "${MAVEN_HOME}:/maven_home" -v ${JAVAZI_MOUNT} -v "${JAVA_HOME}:/java" -v "${OLD_RELEASES_FOLDER}:${OLD_RELEASES_FOLDER}" -v $(pwd):/job_home "${DOCKER_IMAGE}")
 
   if [ "${?}" -ne 0 ]; then
     echo 'Failed to create container.'


### PR DESCRIPTION
OpenJDK8 uses requires an extra folder to be mounted on the docker image to work properly. I also clean up the script a bit to make it a bit more easy to maintain the mount