### PR TITLE
Enable IPv6 in CCI testsuite

### DIFF
--- a/eap-job.sh
+++ b/eap-job.sh
@@ -216,6 +216,11 @@ else
     else
       export TESTSUITE_OPTS="${TESTSUITE_OPTS} -Djboss.dist=${WORKSPACE}/${TEST_JBOSS_DIST}"
     fi
+
+    if [ "${ip}" == "ipv6" ];
+    then
+      export TESTSUITE_OPTS="${TESTSUITE_OPTS} -Dipv6"
+    fi
   fi
 
   unset JBOSS_HOME


### PR DESCRIPTION
Missed the IPv6 option in initial migration