### PR TITLE
Remove new lines from UMB message

### DIFF
--- a/umb-build-message.sh
+++ b/umb-build-message.sh
@@ -62,6 +62,7 @@ msg=$( jq -n '{release: $ARGS.named}' \
 
 echo "${msg}" | jq > message_body.json
 
-echo "MESSAGE_CONTENT=${msg}" >> MESSAGE.txt
+EOL=$'\n'
+echo "MESSAGE_CONTENT=${msg//$EOL/}" >> MESSAGE.txt
 
 cat message_body.json


### PR DESCRIPTION
Remove the new lines so that the property can be correctly read in the job