### PR TITLE
add 7.4.z stream to pr-processor, remove old 7.2.z

### DIFF
--- a/pr-processor.sh
+++ b/pr-processor.sh
@@ -11,8 +11,8 @@ readonly CACHE_NAME=${CACHE_NAME:-'github-cache'}
 readonly CACHE_SIZE=${CACHE_SIZE:-'20'}
 
 declare -a ACTIVES_STREAMS
-ACTIVES_STREAMS[0]='jboss-eap-7.2.z[wildfly-wildfly,wildfly-wildfly-core]'
-ACTIVES_STREAMS[1]='jboss-eap-7.3.z[wildfly-wildfly,wildfly-wildfly-core]'
+ACTIVES_STREAMS[0]='jboss-eap-7.3.z[wildfly-wildfly,wildfly-wildfly-core]'
+ACTIVES_STREAMS[1]='jboss-eap-7.4.z[wildfly-wildfly,wildfly-wildfly-core]'
 
 set -u
 

--- a/tests/pr-processor-test.bats
+++ b/tests/pr-processor-test.bats
@@ -68,7 +68,7 @@ teardown() {
 }
 
 @test "Simple working test case" {
-  local expected_streams='-s jboss-eap-7.2.z[wildfly-wildfly,wildfly-wildfly-core] jboss-eap-7.3.z[wildfly-wildfly,wildfly-wildfly-core] -p jboss-eap-7.2.z[wildfly-wildfly,wildfly-wildfly-core] jboss-eap-7.3.z[wildfly-wildfly,wildfly-wildfly-core]'
+  local expected_streams='-s jboss-eap-7.3.z[wildfly-wildfly,wildfly-wildfly-core] jboss-eap-7.4.z[wildfly-wildfly,wildfly-wildfly-core] -p jboss-eap-7.3.z[wildfly-wildfly,wildfly-wildfly-core] jboss-eap-7.4.z[wildfly-wildfly,wildfly-wildfly-core]'
   local expected_result="java -jar -Daphrodite.config=${APHRODITE_CONFIG} -DcacheDir=${PULL_REQUEST_PROCESSOR_HOME}/cache -DcacheName=github-cache -DcacheSize=20 ${PATH_TO_JAR} ${expected_streams} -f /report.html -w false"
 
   run "${SCRIPT}"


### PR DESCRIPTION
This is same change as https://github.com/jboss-set/harmonia/pull/40 but for olympus branch, 

This configures 7.4.z stream for pr-processor, and also remove and stop run for old 7.2.z stream (no 7.2.z stream is expected).

Please approve and I will merge and activate it after 7.4.0 is QE sign-off.