### PR TITLE
Fix cryo command on passing ${CRYO_COMMAND_ARGS}

### DIFF
--- a/cryo.sh
+++ b/cryo.sh
@@ -98,7 +98,8 @@ echo "CRYO_JAR: ${CRYO_JAR}"
 # do not zip workspace.zip when running eap-job.sh
 unset ZIP_WORKSPACE
 
-java "${CRYO_COMMAND_OPTS}" -jar "${CRYO_JAR}" "${CRYO_COMMAND_ARGS}"
+# shellcheck disable=SC2086
+java ${CRYO_COMMAND_OPTS} -jar "${CRYO_JAR}" ${CRYO_COMMAND_ARGS}
 
 #Create archive to avoid default excludes. Cleanup, tar and compress in place
 mvn clean -DallTests


### PR DESCRIPTION
Only double quotes `"${CRYO_JAR}"`, do not double quote on values