### PR TITLE
produce workspace.zip only when ZIP_WORKSPACE is set to true

### DIFF
--- a/eap-job-64.sh
+++ b/eap-job-64.sh
@@ -173,7 +173,7 @@ if [ "${BUILD_COMMAND}" = 'build' ]; then
     exit "${GIT_SKIP_BISECT_ERROR_CODE}"
   fi
 
-  if [ -n "${ZIP_WORKSPACE}" ]; then
+  if [ "${ZIP_WORKSPACE}" == "true" ]; then
     zip -x "${HARMONIA_FOLDER}" -x \*.zip -qr 'workspace.zip' "${WORKSPACE}"
   fi
 

--- a/eap-job.sh
+++ b/eap-job.sh
@@ -208,7 +208,7 @@ if [ "${BUILD_COMMAND}" = 'build' ]; then
     exit "${GIT_SKIP_BISECT_ERROR_CODE}"
   fi
 
-  if [ -n "${ZIP_WORKSPACE}" ]; then
+  if [ "${ZIP_WORKSPACE}" == "true" ]; then
     zip -x "${HARMONIA_FOLDER}" -x \*.zip -qr 'workspace.zip' "${WORKSPACE}"
   fi
 


### PR DESCRIPTION
`ZIP_WORKSPACE` is set to `false` by default, I think it is intended to not produce `workspace.zip` by default, and only do when it is set to `true`.

This will avoid producing `workspace.zip` for all EAP jobs, and it will save lots of spaces.