### PR TITLE
tests_file points to wrong place

### DIFF
--- a/tests/tests-suite.sh
+++ b/tests/tests-suite.sh
@@ -13,8 +13,8 @@ fi
 runTests() {
   for tests in tests/*.bats
   do
-    local tests_file=$(basename "${1}")
-    bats -t "${tests}" > "${tests_file%.bats}.tap"
+    local tests_file=$(basename "${tests}")
+    bats -t "${tests}" > "tests/${tests_file%.bats}.tap"
   done
 }
 


### PR DESCRIPTION
Place: `runTests()` function in `tests/tests-suite.sh` 

`${1}` should be `${tests}` to be able to run bats testing to produce the `.tap` files. we may need to add extra checks on the tap report on the tests result in the future.