### PR TITLE
Remove MaxPermSize

### DIFF
--- a/eap-job/base.sh
+++ b/eap-job/base.sh
@@ -202,7 +202,7 @@ setup() {
   readonly GIT_SKIP_BISECT_ERROR_CODE=${GIT_SKIP_BISECT_ERROR_CODE:-'125'}
 
   readonly LOCAL_REPO_DIR=${LOCAL_REPO_DIR:-${WORKSPACE}/maven-local-repository}
-  readonly MEMORY_SETTINGS=${MEMORY_SETTINGS:-'-Xmx2048m -Xms1024m -XX:MaxPermSize=512m'}
+  readonly MEMORY_SETTINGS=${MEMORY_SETTINGS:-'-Xmx2048m -Xms1024m'}
 
   readonly BUILD_OPTS=${BUILD_OPTS:-'-Drelease'}
 


### PR DESCRIPTION
Part of https://projects.engineering.redhat.com/browse/SET-422 

MaxPermSize is not used since JDK8 and was removed later