### PR TITLE
Add condition to use dist/target in XP builds with eap-job.sh

### DIFF
--- a/eap-job.sh
+++ b/eap-job.sh
@@ -68,6 +68,10 @@ function get_dist_folder() {
         dist_folder="ee-dist/target"
     fi
 
+    if [ -n "${IS_XP}" ]; then
+        dist_folder="dist/target"
+    fi
+
     echo "${dist_folder}"
 }
 


### PR DESCRIPTION
The jobs in CCI fail because they are trying to use ee-dist instead of dist in XP.