### PR TITLE
Fix EAP 6.4 testsuite

### DIFF
--- a/eap-job-cci-eap64-testsuite.sh
+++ b/eap-job-cci-eap64-testsuite.sh
@@ -49,4 +49,4 @@ if [ "${jdk}" != "IBM_JDK8" ]; then
   fi
   rm "${CONSOLE_LOG}"
 fi
-xit "${status_code}"
+exit "${status_code}"

--- a/eap-job-cci-eap64-testsuite.sh
+++ b/eap-job-cci-eap64-testsuite.sh
@@ -28,7 +28,7 @@ if [ -z "${NO_ZIPFILES}" ]; then
 fi
 
 export TESTSUITE_OPTS="${TESTSUITE_OPTS} -Dsurefire.rerunFailingTestsCount=2"
-#export TESTSUITE_OPTS="${TESTSUITE_OPTS} -Dorg.jboss.model.test.jbossdeveloper.repourl=http://localhost/repos/"
+export TESTSUITE_OPTS="${TESTSUITE_OPTS} -Dorg.jboss.model.test.jbossdeveloper.repourl=https://repository.jboss.org/"
 export TESTSUITE_OPTS="${TESTSUITE_OPTS} -Dorg.jboss.model.test.eap.repourl=http://download.lab.bos.redhat.com/brewroot/repos/jb-eap-6.4-rhel-6-build/latest/maven/"
 
 ./build.sh clean install -fae -B -Dts.noSmoke -s "${MAVEN_SETTINGS_XML}" ${TESTSUITE_OPTS}
@@ -49,4 +49,4 @@ if [ "${jdk}" != "IBM_JDK8" ]; then
   fi
   rm "${CONSOLE_LOG}"
 fi
-exit "${status_code}"
+xit "${status_code}"


### PR DESCRIPTION
The EAP 6.4 testsuite requires the system property `org.jboss.model.test.jbossdeveloper.repourl` to point to un-productised releases of EAP.