### PR TITLE
use pip-3 instead of pip-3.8 default

### DIFF
--- a/molecule.sh
+++ b/molecule.sh
@@ -173,7 +173,7 @@ readonly SCENARIO_DRIVER_NAME=${2:-'delegated'}
 readonly SCENARIO_HERA_DRIVER_DIR="${WORKSPACE}/eris/molecule/olympus/"
 readonly ANSIBLE_CONFIG=${ANSIBLE_CONFIG:-'/var/jenkins_home/ansible.cfg'}
 readonly PYTHON_REQUIREMENTS_FILE=${PYTHON_REQUIREMENTS_FILE:-'requirements.txt'}
-readonly PIP_COMMAND=${PIP_COMMAND:-'pip-3.8'}
+readonly PIP_COMMAND=${PIP_COMMAND:-'pip-3'}
 
 readonly MOLECULE_CACHE_ROOT=${MOLECULE_CACHE_ROOT:-"${HOME}/.cache/molecule/"}
 readonly MOLECULE_KEEP_CACHE=${MOLECULE_KEEP_CACHE:-''}


### PR DESCRIPTION
using pip-3 (alternatives) should be compatible with both python 3.8 (rhel8/aap2.1) and python 3.9 (rhel9/aap2.2)