### PR TITLE
Fix double slashes in SERVER_URL and SOURCE_URL

### DIFF
--- a/eap-job/base.sh
+++ b/eap-job/base.sh
@@ -184,8 +184,8 @@ record_build_properties() {
 
   # shellcheck disable=SC2129
   echo "BUILD_URL=${BUILD_URL}" >> ${PROPERTIES_FILE}
-  echo "SERVER_URL=${BUILD_URL}/artifact/jboss-eap-dist-${GIT_COMMIT:0:7}.zip" >> ${PROPERTIES_FILE}
-  echo "SOURCE_URL=${BUILD_URL}/artifact/jboss-eap-src-${GIT_COMMIT:0:7}.zip" >> ${PROPERTIES_FILE}
+  echo "SERVER_URL=${BUILD_URL}artifact/jboss-eap-dist-${GIT_COMMIT:0:7}.zip" >> ${PROPERTIES_FILE}
+  echo "SOURCE_URL=${BUILD_URL}artifact/jboss-eap-src-${GIT_COMMIT:0:7}.zip" >> ${PROPERTIES_FILE}
   echo "VERSION=${EAP_VERSION}-${GIT_COMMIT:0:7}" >> ${PROPERTIES_FILE}
   echo "BASE_VERSION=${EAP_VERSION}" >> ${PROPERTIES_FILE}
   echo "BUILD_ID=${BUILD_ID}" >> ${PROPERTIES_FILE}


### PR DESCRIPTION
Minor fix for double slashes in SERVER_URL and SOURCE_URL.

I came across this when I looked at the new pipeline. 
```
BUILD_URL=https://eapdev-jenkins-csb-jbossset.apps.ocp-c1.prod.psi.redhat.com/job/eap-8.0/job/aligned-eap-8.0-build/37/
SERVER_URL=https://eapdev-jenkins-csb-jbossset.apps.ocp-c1.prod.psi.redhat.com/job/eap-8.0/job/aligned-eap-8.0-build/37//artifact/jboss-eap-dist-483eee7.zip
SOURCE_URL=https://eapdev-jenkins-csb-jbossset.apps.ocp-c1.prod.psi.redhat.com/job/eap-8.0/job/aligned-eap-8.0-build/37//artifact/jboss-eap-src-483eee7.zip
```
E.g. https://eapdev-jenkins-csb-jbossset.apps.ocp-c1.prod.psi.redhat.com/job/eap-8.0/job/aligned-eap-8.0-build/37/consoleFull 



The Jenkins `BUILD_URL` env variable described here https://wiki.jenkins.io/display/JENKINS/Building+a+software+project
