### PR TITLE
Fix if condition for zip workspace and remove redundant step in build()

### DIFF
--- a/eap-job/base.sh
+++ b/eap-job/base.sh
@@ -145,7 +145,7 @@ build() {
     exit "${GIT_SKIP_BISECT_ERROR_CODE}"
   fi
 
-  if [ -n "${ZIP_WORKSPACE}" ]; then
+  if [[ "${ZIP_WORKSPACE}" = "true" ]]; then
     zip -x "${HARMONIA_FOLDER}" -x \*.zip -qr 'workspace.zip' "${WORKSPACE}"
   fi
 }

--- a/eap-job/cci.sh
+++ b/eap-job/cci.sh
@@ -14,10 +14,6 @@ pre_build() {
 }
 
 post_build() {
-  if [ -n "${ZIP_WORKSPACE}" ]; then
-    zip -x "${HARMONIA_FOLDER}" -x \*.zip -qr 'workspace.zip' "${WORKSPACE}"
-  fi
-
   # shellcheck disable=SC2155
   readonly EAP_DIST_DIR=$(get_dist_folder)
   echo "Using ${EAP_DIST_DIR}"


### PR DESCRIPTION
Remove redundant step in `post_build()`, already done in `build()`

Also the if condition seems wrong to me when you assign a default value to `ZIP_WORKSPACE` in `base.sh`

`readonly ZIP_WORKSPACE=${ZIP_WORKSPACE:-'false'}`