### PR TITLE
molecule: allow slave image to be overriden by job

### DIFF
--- a/ansible/molecule/common.sh
+++ b/ansible/molecule/common.sh
@@ -34,7 +34,7 @@ determineMoleculeDriverName() {
 
 readonly HARMONIA_MOLECULE_DEFAULT_DRIVER_NAME=$(determineMoleculeDriverName)
 echo "DEBUG> ${HARMONIA_MOLECULE_DEFAULT_DRIVER_NAME}"
-readonly HERA_MOLECULE_SLAVE_IMAGE=$(determineMoleculeSlaveImage)
+readonly HERA_MOLECULE_SLAVE_IMAGE=${HERA_MOLECULE_SLAVE_IMAGE:-"$(determineMoleculeSlaveImage)"}
 export HERA_MOLECULE_SLAVE_IMAGE
 
 deployHeraDriver() {


### PR DESCRIPTION
@guidograzioli FYI

If the slave image is not provided by the job, harmonia will use the molecule version to determine which slave image to use.