### PR TITLE
eap: ensure MAVEN_VERBOSE being set always translate to -X

### DIFF
--- a/eap-job/base.sh
+++ b/eap-job/base.sh
@@ -252,7 +252,10 @@ setup() {
     shift
   fi
 
-  readonly MAVEN_VERBOSE=${MAVEN_VERBOSE}
+  if [ ! -z "${MAVEN_VERBOSE}" ]; then
+    readonly MAVEN_VERBOSE='-X'
+  fi
+
   readonly GIT_SKIP_BISECT_ERROR_CODE=${GIT_SKIP_BISECT_ERROR_CODE:-'125'}
 
   readonly LOCAL_REPO_DIR=${LOCAL_REPO_DIR:-${WORKSPACE}/maven-local-repository}


### PR DESCRIPTION
Not sure about this one... It might improve usability, but I liked the transparency of what you set in MAVEN_VERBOSE is what is added to the cli... 🤷

(it also needs to be tested, I'm just tossing the idea for now)